### PR TITLE
Tweak ESLint to use our custom eslint-config-universal-search config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,16 +1,6 @@
+extends: universal-search
+
 parser: babel-eslint
 
-env:
-  browser: true
-  es6: true
-  node: true
-
 rules:
-  indent: [2, 2]
   no-console: 0
-  no-underscore-dangle: 0
-  no-unused-expressions: 0
-  no-unused-vars: [2, {vars: all, args: none}]
-  no-use-before-define: [2, nofunc]
-  quotes: [2, single]
-  strict: 0

--- a/package.json
+++ b/package.json
@@ -1,16 +1,11 @@
 {
   "name": "universal-search-content",
+  "description": "the iframe that we put inside the autocomplete dropdown",
   "version": "0.0.1",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "build": "webpack --optimize-minimize --optimize-dedupe",
-    "lint": "eslint .",
-    "start": "webpack-dev-server",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "author": "Mozilla",
-  "license": "MPL-2.0",
+  "bugs": {
+    "url": "https://github.com/mozilla/universal-search-content/issues"
+  },
   "dependencies": {
     "ampersand-app": "^1.0.4",
     "ampersand-collection": "^1.4.5",
@@ -38,6 +33,21 @@
   "devDependencies": {
     "babel-eslint": "3.1.20",
     "eslint": "0.24.0",
+    "eslint-config-universal-search": "1.0.0",
     "webpack-dev-server": "^1.10.1"
+  },
+  "homepage": "https://github.com/mozilla/universal-search-content#readme",
+  "license": "MPL-2.0",
+  "main": "index.js",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mozilla/universal-search-content.git"
+  },
+  "scripts": {
+    "build": "webpack --optimize-minimize --optimize-dedupe",
+    "lint": "eslint .",
+    "start": "webpack-dev-server",
+    "test": "echo \"Error: no test specified\" && exit 1"
   }
 }

--- a/src/views/activity/activity_index_view.js
+++ b/src/views/activity/activity_index_view.js
@@ -20,7 +20,7 @@ export default BaseView.extend({
     this.renderCollection(this.adapter.results, ActivityItemView, '.activity-results');
 
     // if there are results then show otherwise hide
-    this.adapter.results.length ? this.show() : this.hide();
+    this.adapter.results.length ? this.show() : this.hide(); // eslint-disable-line no-unused-expressions
 
     console.timeEnd('render: ActivityIndex');
   }

--- a/src/views/top_hits/top_hits_index_view.js
+++ b/src/views/top_hits/top_hits_index_view.js
@@ -22,7 +22,7 @@ export default BaseView.extend({
     this.renderCollection(new ActivityResults([this.adapter.results.at(0)]), ActivityItemView, '.top-hits-results');
 
     // if there are results then show otherwise hide
-    this.adapter.results.length ? this.show() : this.hide();
+    this.adapter.results.length ? this.show() : this.hide(); // eslint-disable-line no-unused-expressions
 
     console.timeEnd('render: TopHitsIndex');
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = {
     ]
   },
   devServer: {
-    contentBase: "./dist",
+    contentBase: './dist',
     https: true
   }
 };


### PR DESCRIPTION
If you have a globally installed ESLint, you'll need to run `eslint` using the `npm run lint` task.
It's kind of a weird state where the globally installed ESLint will look for the **eslint-config-universal-search** in the global npm modules too.

Running `npm run lint` currently shows 0 errors/warnings!
