### PR TITLE
Fix clicks

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -16,6 +16,7 @@ html {
   box-sizing: inherit;
   font-size: 12px;
   font-weight: normal;
+  -moz-user-select: none;
   user-select: none;
 }
 

--- a/src/views/activity/activity_item_view.js
+++ b/src/views/activity/activity_item_view.js
@@ -6,12 +6,16 @@ export default BaseView.extend({
   template: ActivityItemView,
 
   events: {
-    'click': 'openUrl',
+    'mousedown': 'openUrl',
     'select': 'sendSelectionDetails'
   },
 
   openUrl (event) {
-    webChannel.sendAutocompleteClick(this.model.url, 'url');
+    // we have to use mousedown, not click, because of browser bugs.
+    // see https://github.com/mozilla/universal-search-addon/issues/20 for more.
+    if (event.which === 1) {
+      webChannel.sendAutocompleteClick(this.model.url, 'url');
+    }
   },
 
   sendSelectionDetails (event) {

--- a/src/views/search_suggestions/search_suggestions_item_view.js
+++ b/src/views/search_suggestions/search_suggestions_item_view.js
@@ -6,12 +6,16 @@ export default BaseView.extend({
   template: SearchSuggestionsItemTemplate,
 
   events: {
-    'click': 'openSuggestion',
+    'mousedown': 'openSuggestion',
     'select': 'sendSelectionDetails'
   },
 
   openSuggestion (event) {
-    webChannel.sendAutocompleteClick(this.model.term, 'suggestion');
+    // we have to use mousedown, not click, because of browser bugs.
+    // see https://github.com/mozilla/universal-search-addon/issues/20 for more.
+    if (event.which === 1) {
+      webChannel.sendAutocompleteClick(this.model.term, 'suggestion');
+    }
   },
 
   sendSelectionDetails (event) {


### PR DESCRIPTION
@nchapman @johngruen @pdehaan TL;DR: This is a goofy hack that we probably shouldn't merge, but then, maybe we should.

Quick refresher: the sequence of DOM events fired during a mouse click is: mousedown, mouseup, click. If you move the mouse during that sequence, then lots and lots of mousemove events will fire in between the other events.

As far as I can tell, if you click+drag, the XUL popup hides itself during the mousemove, so that when the click event fires, it doesn't fire on the popup (I haven't figured out where that click goes). This means that if you click with zero finger motion on a touchpad, the popup should work (that is, the click travels down to the iframe and the iframe click handler fires a url back to the browser), but if you move your finger slightly while clicking, the mousedown, mouseup, click sequence doesn't fire on the iframe. Only the mousedown fires on the iframe.

After changing the iframe code to use mousedown, not click, there are two remaining ugly bugs in the browser behavior: first, sometimes the text contents of the iframe _still_ get selected, despite tossing a -moz-user-select:none in there (this seems to be a text selection event fired by XUL?); second, the urlbar doesn't get focus when you click on it after the popup closes. You have to click twice (this is because, in a bizarre twist of fate, the first click actually dismisses the popup...which is hidden (?!?!?!)).

Blargh. THoughts / comments welcome. I think we should land this and I"ll fix the two relatively minor browser bugs and/or continue tracking down a better fix on the browser side. At any rate, moving from click to mousedown never hurt anybody ^_^
