### PR TITLE
Convert webpack flags to options in webpack config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "webpack --optimize-minimize --optimize-dedupe",
+    "build": "webpack",
     "lint": "eslint .",
     "start": "webpack-dev-server",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,8 @@
+const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const DedupePlugin = webpack.optimize.DedupePlugin;
+const UglifyJsPlugin = webpack.optimize.UglifyJsPlugin;
 
 module.exports = {
   entry: './src/main.js',
@@ -10,6 +14,12 @@ module.exports = {
     new HtmlWebpackPlugin({
       hash: true,
       title: 'Universal Search'
+    }),
+    new DedupePlugin(),
+    new UglifyJsPlugin({
+      compress: {
+        warnings: false
+      }
     })
   ],
   module: {


### PR DESCRIPTION
Per http://webpack.github.io/docs/list-of-plugins.html (see [DedupePlugin](http://webpack.github.io/docs/list-of-plugins.html#dedupeplugin) and [UglifyJsPlugin](http://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin))

This lets us remove the config from the command line flags (ie: `webpack --optimize-minimize --optimize-dedupe` and put them directly in the webpack.config.js file).
Not a huge gain, but makes it a lot easier when we want to switch to ~~Grunt~~ Gulp or something:

``` js
module.exports = function (grunt) {
  grunt.loadNpmTasks('grunt-webpack');

  grunt.initConfig({
    webpack: {
      app: require('./webpack.config')
    }
  });
};
```

---

**UPDATE:** Basic Gulp example added in https://github.com/mozilla/universal-search-content/issues/36#issuecomment-122417435.
