### PR TITLE
Add gulp for webpack and eslint tasks

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,0 +1,38 @@
+import {union} from 'lodash';
+import del from 'del';
+import eslint from 'gulp-eslint';
+import gulp from 'gulp';
+import webpack from 'webpack';
+
+import webpackConfig from './webpack.config.js';
+
+const WEBPACK_PROD_PLUGINS = [
+  new webpack.optimize.DedupePlugin(),
+  new webpack.optimize.UglifyJsPlugin({
+    compress: {
+      warnings: false
+    }
+  })
+];
+
+webpackConfig.plugins = union(webpackConfig.plugins || [], WEBPACK_PROD_PLUGINS);
+
+gulp.task('eslint', function () {
+  return gulp.src(['*.js', 'src/**/*.js'])
+    .pipe(eslint())
+    .pipe(eslint.failOnError());
+});
+
+gulp.task('clean:dist', function (callback) {
+  del(['dist'], callback);
+});
+
+gulp.task('webpack', ['clean:dist'], function (callback) {
+  webpack(webpackConfig).run(function (err, stats) {
+    callback(err);
+  });
+});
+
+gulp.task('default', ['build']);
+gulp.task('lint', ['eslint']);
+gulp.task('build', ['lint', 'webpack']);

--- a/package.json
+++ b/package.json
@@ -33,21 +33,23 @@
   },
   "devDependencies": {
     "babel-eslint": "4.0.5",
-    "eslint": "0.24.0",
-    "eslint-config-universal-search": "1.0.0",
+    "del": "1.2.0",
+    "eslint-config-universal-search": "2.0.0",
+    "gulp": "3.9.0",
+    "gulp-eslint": "1.0.0",
     "webpack-dev-server": "^1.10.1"
   },
   "homepage": "https://github.com/mozilla/universal-search-content#readme",
   "license": "MPL-2.0",
-  "main": "index.js",
+  "main": "src/main.js",
   "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mozilla/universal-search-content.git"
   },
   "scripts": {
-    "build": "webpack --optimize-minimize --optimize-dedupe",
-    "lint": "eslint .",
+    "build": "gulp build",
+    "lint": "gulp lint",
     "start": "webpack-dev-server",
     "test": "echo \"Error: no test specified\" && exit 1"
   }


### PR DESCRIPTION
This leaves the ./webpack.config.js file intact and injects the plugins in the gulpfile.js (as to not pollute the dev server).

r? @nchapman 

Fixes #36 
