### PR TITLE
Convert `var` to `let` and disallow `var` usage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,3 +4,4 @@ parser: babel-eslint
 
 rules:
   no-console: 0
+  no-var: 2

--- a/src/views/index_view.js
+++ b/src/views/index_view.js
@@ -29,7 +29,7 @@ export default BaseView.extend({
     if (selectedItem) {
       // trick the element into navigating
       // TODO: use JS events, not DOM events, for signaling (issue #37)
-      var fakeClick = new CustomEvent('mousedown');
+      let fakeClick = new CustomEvent('mousedown');
       fakeClick.which = 1;
       selectedItem.dispatchEvent(fakeClick);
     }
@@ -58,7 +58,7 @@ export default BaseView.extend({
 
   _selectNextItem (increment) {
     const items = document.querySelectorAll('li');
-    var newlySelected;
+    let newlySelected;
 
     Array.prototype.some.call(items, function (item, i) {
       if (dom.hasClass(item, 'selected')) {


### PR DESCRIPTION
Rule: http://eslint.org/docs/rules/no-var.html
