### PR TITLE
Send messages to the last-seen WebChannel id.

### DIFF
--- a/src/lib/web_channel.js
+++ b/src/lib/web_channel.js
@@ -7,12 +7,14 @@ class WebChannel {
 
     // listen for WebChannel messages
     window.addEventListener('WebChannelMessageToContent', this._messageReceived.bind(this));
+
+    this.channelId = null;
   }
 
   sendMessage (type, data) {
     window.dispatchEvent(new window.CustomEvent('WebChannelMessageToChrome', {
       detail: {
-        id: 'ohai',
+        id: this.channelId,
         message: {
           type: type,
           data: data
@@ -36,8 +38,12 @@ class WebChannel {
   }
 
   _messageReceived (e) {
-    const message = e.detail.message;
+    const newChannelId = e.detail.id;
+    if (this.channelId !== newChannelId) {
+      this.channelId = newChannelId;
+    }
 
+    const message = e.detail.message;
     if (message && message.data) {
       this.trigger(message.type, message.data);
     }


### PR DESCRIPTION
Corresponds to bug mozilla/universal-search-addon#64 and PR mozilla/universal-search-addon#82, in which we start setting a per-window unique WebChannel id. Store this id on the iframe by setting it when you see it in a message.

r? @nchapman @pdehaan
