### PR TITLE
Update README.md with new docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ the iframe that we put inside the autocomplete dropdown
 
 ## postmessage API docs
 
-https://gist.github.com/6a68/48bf56e5b66e8631b522
+https://github.com/mozilla/universal-search-addon/blob/master/docs/API.md
 
 ## debugging and performance tuning
 


### PR DESCRIPTION
Now that mozilla/universal-search-addon#85 has landed, update the postmessage API link to point at the repo, not the old gist.

@nchapman r?
