### PR TITLE
First prototype integration of little machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "html-webpack-plugin": "^1.5.0",
     "loader-utils": "^0.2.10",
     "lodash": "^3.9.3",
+    "lodash.debounce": "^3.1.1",
     "mustache-loader": "^0.3.0",
     "node-libs-browser": "^0.5.2",
     "node-normalize-scss": "1.0.3",

--- a/src/adapters/lil_mac_adapter.js
+++ b/src/adapters/lil_mac_adapter.js
@@ -1,0 +1,36 @@
+import debounce from 'lodash.debounce';
+import webChannel from '../lib/web_channel';
+import LilMacResults from '../collections/lil_mac_results';
+
+class LilMacAdapter {
+  constructor () {
+    this.results = new LilMacResults();
+    webChannel.on('printable-key', debounce((data) => {
+      this.search(data.query);
+    }, 150));
+  }
+
+  search(term) {
+    // XXX Override the search endpoint by setting window.app.searchUrl in a
+    //     debugger window :-)
+    const searchUrl = window.app.searchUrl || 'https://little-machine.herokuapp.com/search/autocomplete.json?q=';
+    const url = searchUrl + encodeURI(term);
+    const xhr = new XMLHttpRequest();
+
+    xhr.open('GET', url, true);
+    xhr.onload = () => {
+      if (xhr.readyState === 4 && xhr.status === 200) {
+        let results = [];
+        try {
+          results = JSON.parse(xhr.response);
+        } catch (e) {} // eslint-disable-line no-empty
+        this.results.reset(results);
+      }
+    };
+    xhr.send();
+  }
+
+}
+
+// export singleton
+export default new LilMacAdapter();

--- a/src/collections/lil_mac_results.js
+++ b/src/collections/lil_mac_results.js
@@ -1,0 +1,7 @@
+import Collection from 'ampersand-collection';
+import LilMacResult from '../models/lil_mac_result';
+
+export default Collection.extend({
+  model: LilMacResult
+});
+

--- a/src/models/lil_mac_result.js
+++ b/src/models/lil_mac_result.js
@@ -1,0 +1,12 @@
+import State from 'ampersand-state';
+
+// what's in a name?
+//
+// little machine => little mac (mike tyson's punchout) =>
+// => lil mac: the crappier prototype version of little mac
+// arguably, glass_joe would have been more appropriate
+
+export default State.extend({
+  extraProperties: 'allow'
+});
+

--- a/src/templates/top_hits/index.html
+++ b/src/templates/top_hits/index.html
@@ -1,3 +1,4 @@
 <div class="top-hits-index result-region">
   <ol class="top-hits-results"></ol>
+  <ol class="lil-mac-results"></ol>
 </div>

--- a/src/views/top_hits/top_hits_index_view.js
+++ b/src/views/top_hits/top_hits_index_view.js
@@ -2,15 +2,19 @@ import BaseView from '../base_view';
 import TopHitsIndexTemplate from '../../templates/top_hits/index.html';
 import ActivityItemView from '../activity/activity_item_view';
 import ActivityResults from '../../collections/activity_results';
+import LilMacResults from '../../collections/lil_mac_results';
 import activityResultsAdapter from '../../adapters/activity_results_adapter';
+import lilMacAdapter from '../../adapters/lil_mac_adapter';
 
 export default BaseView.extend({
   template: TopHitsIndexTemplate,
 
   initialize () {
     this.adapter = activityResultsAdapter;
+    this.lilmac = lilMacAdapter;
 
     this.listenTo(this.adapter.results, 'reset', this.render);
+    this.listenTo(this.lilmac.results, 'reset', this.render);
   },
 
   afterRender () {
@@ -19,7 +23,10 @@ export default BaseView.extend({
     // TODO: replace this with proper top hits dispatching
     this.renderCollection(new ActivityResults([this.adapter.results.at(0)]), ActivityItemView, '.top-hits-results');
 
+    // TODO: obviously this is insane. mix result types properly
+    this.renderCollection(new LilMacResults([this.lilmac.results.at(0)]), ActivityItemView, '.lil-mac-results');
+
     // if there are results then show otherwise hide
-    this.adapter.results.length ? this.show() : this.hide(); // eslint-disable-line no-unused-expressions
+    (this.adapter.results.length || this.lilmac.results.length) ? this.show() : this.hide(); // eslint-disable-line no-unused-expressions
   }
 });


### PR DESCRIPTION
@nchapman r?

This change corresponds with the change in universal-search-addon that sends over a `printable-keys` event (which actually contains the contents of the urlbar).
1. KeystrokesAdapter listens for `printable-keys` signal, xhrs the query to little-machine
   - As noted in the parallel addon PR, this event will not be sent if the user is in private browsing mode
2. KeystrokesAdapter puts the little machine response into a collection of LilMacResults
3. The Top Hits view listens for changes on that collection, and re-renders accordingly.
4. Updated Top Hits show/hide logic to include the suggestion.

This is deliberately as simple as possible, without being egregiously awful to look at. I'm open to using less-ridiculous names for things; the idea was to keep it sounding obviously not finished, to provoke revisiting decisions sooner than later.

The quality of results is really pretty amazing for such a small prototype:

<img width="740" alt="screenshot 2015-10-23 16 43 34" src="https://cloud.githubusercontent.com/assets/96396/10707302/4d9fbe9e-79a5-11e5-8573-c133a90d3ca5.png">

Anyway, go little mac!

![](https://media.giphy.com/media/MHACxxrd00L2E/giphy.gif)
