### PR TITLE
Adds 'moz-action:switchtab,' prefix before navigating to URLs of open tabs (closes #103).

### DIFF
--- a/src/views/activity/activity_item_view.js
+++ b/src/views/activity/activity_item_view.js
@@ -14,7 +14,8 @@ export default BaseView.extend({
     // we have to use mousedown, not click, because of browser bugs.
     // see https://github.com/mozilla/universal-search-addon/issues/20 for more.
     if (event.which === 1) {
-      webChannel.sendAutocompleteClick(this.model.url, 'url');
+      const prefix = this.model.type === 'action' ? 'moz-action:switchtab,' : '';
+      webChannel.sendAutocompleteClick(prefix + this.model.url, 'url');
     }
   },
 


### PR DESCRIPTION
r? @6a68 
