### PR TITLE
Shows the title and URL segments for bookmark results (fixes #108).

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -221,10 +221,12 @@ ol {
 .result.recommended .segment.abstract,
 .result.recommended .segment.url,
 .result.search .segment.title,
-.result.action .segment.action,
 .result.favicon .segment.title,
 .result.favicon .segment.url,
+.result.bookmark .segment.title,
+.result.bookmark .segment.url,
 .result.action .segment.title,
+.result.action .segment.action,
 .result.action .segment.url {
   display: block;
 }


### PR DESCRIPTION
<img width="777" alt="screen shot 2015-12-04 at 8 18 53 am" src="https://cloud.githubusercontent.com/assets/23885/11593160/f5d1e4f4-9a5f-11e5-9ac7-bba578310d92.png">

r? @6a68 
