### PR TITLE
Prevents action text from truncation, wrapping (closes #123).

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -172,8 +172,8 @@ ol {
   }
 
   &.action {
-    @include ellipsis(30%);
     color: $color--green;
+    white-space: nowrap;
   }
 
   &.abstract{


### PR DESCRIPTION
r? @6a68 

<img width="468" alt="screen shot 2015-12-06 at 5 40 19 pm" src="https://cloud.githubusercontent.com/assets/23885/11616758/ac68db82-9c40-11e5-8e47-30824ca37616.png">
