### PR TITLE
Don't clear the key selection on mouseenter (fixes #98)

### DIFF
--- a/src/views/index_view.js
+++ b/src/views/index_view.js
@@ -16,10 +16,6 @@ import dom from 'ampersand-dom';
 export default BaseView.extend({
   template: IndexTemplate,
 
-  events: {
-    'mouseenter': 'clearSelection'
-  },
-
   initialize () {
     // listen for chrome key events
     this.listenTo(webChannel, 'navigational-key', this.dispatchKeypress);
@@ -61,14 +57,6 @@ export default BaseView.extend({
     // enter triggers a navigation
     } else if (data.key === 'Enter') {
       this._handleEnter();
-    }
-  },
-
-  clearSelection (e) {
-    let selectedItem = this.query('li.selected');
-
-    if (selectedItem) {
-      dom.removeClass(selectedItem, 'selected');
     }
   },
 


### PR DESCRIPTION
@chuckharmston r?

I'm not totally clear on the history here, but it looks like we used to manage the mouse highlight via the `selected` class, where it's now handled via CSS. Removing the `mouseenter` handler keeps the mouse movement from affecting the blue key highlight.
