### PR TITLE
Refactor views

### DIFF
--- a/src/models/activity_result.js
+++ b/src/models/activity_result.js
@@ -3,11 +3,29 @@ import State from 'ampersand-state';
 export default State.extend({
   extraProperties: 'allow',
 
-  displayTitle () {
-    return this.bookmark ? this.bookmark.title : this.title;
-  },
-
-  displayImage () {
-    return this.imageData ? this.imageData : this.image;
+  resultType: 'url',
+  derived: {
+    result: {
+      deps: ['url'],
+      fn: function() {
+        const prefix = this.type === 'action' ? 'moz-action:switchtab,' : '';
+        return prefix + this.url;
+      },
+      cache: false
+    },
+    displayTitle: {
+      deps: ['bookmark', 'title'],
+      fn: function() {
+        return this.bookmark ? this.bookmark.title : this.title;
+      },
+      cache: false
+    },
+    displayImage: {
+      deps: ['imageData', 'image'],
+      fn: function() {
+        return this.imageData ? this.imageData : this.image;
+      },
+      cache: false
+    }
   }
 });

--- a/src/models/recommended_result.js
+++ b/src/models/recommended_result.js
@@ -1,17 +1,25 @@
 import State from 'ampersand-state';
 
-// what's in a name?
-//
-// little machine => little mac (mike tyson's punchout) =>
-// => lil mac: the crappier prototype version of little mac
-// arguably, glass_joe would have been more appropriate
-
 export default State.extend({
   extraProperties: 'allow',
 
-  faviconUrl () {
-    if (this.favicon) {
-      return this.favicon.url;
+  resultType: 'url',
+  derived: {
+    result: {
+      deps: ['url'],
+      fn: function() {
+        return this.url;
+      },
+      cache: false
+    },
+    faviconUrl: {
+      deps: ['favicon'],
+      fn: function() {
+        if (this.favicon) {
+          return this.favicon.url;
+        }
+      },
+      cache: false
     }
   }
 });

--- a/src/models/search_suggestion.js
+++ b/src/models/search_suggestion.js
@@ -1,5 +1,17 @@
 import State from 'ampersand-state';
 
 export default State.extend({
-  extraProperties: 'allow'
+  extraProperties: 'allow',
+
+  // TODO: better name?
+  resultType: 'suggestion',
+  derived: {
+    result: {
+      deps: ['term'],
+      fn: function() {
+        return this.term;
+      },
+      cache: false
+    }
+  }
 });

--- a/src/templates/activity/item.html
+++ b/src/templates/activity/item.html
@@ -4,6 +4,7 @@
   <div class="segments">
     <span class="segment title">{{{model.displayTitle}}}</span>
     <span class="segment action">Switch to Tab</span>
+    <p style="font-size: 11px;color: #555">{{model.description}}</p>
     <span class="segment url">{{model.url}}</span>
   </div>
 </li>

--- a/src/views/activity/activity_item_view.js
+++ b/src/views/activity/activity_item_view.js
@@ -1,9 +1,9 @@
-import ActivityItemView from '../../templates/activity/item.html';
+import ActivityItemTemplate from '../../templates/activity/item.html';
 import Favicon from '../../lib/image_colors';
 import RowItemView from '../row_item_view';
 
 export default RowItemView.extend({
-  template: ActivityItemView,
+  template: ActivityItemTemplate,
 
   events: RowItemView.prototype.events,
 

--- a/src/views/activity/activity_item_view.js
+++ b/src/views/activity/activity_item_view.js
@@ -34,7 +34,15 @@ export default BaseView.extend({
     // allowing us to handle events directly, since load events don't bubble
     // and cannot be delegated.
     this.icon = new Image('img');
-    this.icon.onload = () => { this.calculateIconColor(); };
+    this.icon.onload = () => {
+      // if we have the fancy image, show it under the favicon. otherwise, do the bkgd color thing
+      if (this.model.fancyImageData) {
+        this.iconContainer.style.cssText =
+          'background-size: cover; background-image: url("' + this.model.fancyImageData + '");';
+      } else {
+        this.calculateIconColor();
+      }
+    };
     this.icon.onerror = () => { this.hideErroredFavicon(); };
     this.icon.src = this.model.displayImage();
     this.iconContainer.appendChild(this.icon);

--- a/src/views/activity/activity_item_view.js
+++ b/src/views/activity/activity_item_view.js
@@ -20,13 +20,12 @@ export default BaseView.extend({
     // we have to use mousedown, not click, because of browser bugs.
     // see https://github.com/mozilla/universal-search-addon/issues/20 for more.
     if (event.which === 1) {
-      const prefix = this.model.type === 'action' ? 'moz-action:switchtab,' : '';
-      webChannel.sendAutocompleteClick(prefix + this.model.url, 'url');
+      webChannel.sendAutocompleteClick(this.model.result, this.model.resultType);
     }
   },
 
   sendSelectionDetails (event) {
-    webChannel.sendUrlSelected(this.model.url, 'url');
+    webChannel.sendUrlSelected(this.model.result, this.model.resultType);
   },
 
   injectFavicon () {
@@ -44,7 +43,7 @@ export default BaseView.extend({
       }
     };
     this.icon.onerror = () => { this.hideErroredFavicon(); };
-    this.icon.src = this.model.displayImage();
+    this.icon.src = this.model.displayImage;
     this.iconContainer.appendChild(this.icon);
   },
 

--- a/src/views/activity/activity_item_view.js
+++ b/src/views/activity/activity_item_view.js
@@ -1,31 +1,15 @@
-import BaseView from '../base_view';
 import ActivityItemView from '../../templates/activity/item.html';
 import Favicon from '../../lib/image_colors';
-import webChannel from '../../lib/web_channel';
+import RowItemView from '../row_item_view';
 
-export default BaseView.extend({
+export default RowItemView.extend({
   template: ActivityItemView,
 
-  events: {
-    'mousedown': 'openUrl',
-    'select': 'sendSelectionDetails'
-  },
+  events: RowItemView.prototype.events,
 
   afterRender () {
     this.iconContainer = this.query('.icon.favicon');
     this.injectFavicon();
-  },
-
-  openUrl (event) {
-    // we have to use mousedown, not click, because of browser bugs.
-    // see https://github.com/mozilla/universal-search-addon/issues/20 for more.
-    if (event.which === 1) {
-      webChannel.sendAutocompleteClick(this.model.result, this.model.resultType);
-    }
-  },
-
-  sendSelectionDetails (event) {
-    webChannel.sendUrlSelected(this.model.result, this.model.resultType);
   },
 
   injectFavicon () {

--- a/src/views/index_view.js
+++ b/src/views/index_view.js
@@ -16,10 +16,6 @@ import dom from 'ampersand-dom';
 export default BaseView.extend({
   template: IndexTemplate,
 
-  events: {
-    'mouseenter': 'clearSelection'
-  },
-
   initialize () {
     // listen for chrome key events
     this.listenTo(webChannel, 'navigational-key', this.dispatchKeypress);
@@ -61,14 +57,6 @@ export default BaseView.extend({
     // enter triggers a navigation
     } else if (data.key === 'Enter') {
       this._handleEnter();
-    }
-  },
-
-  clearSelection (e) {
-    let selectedItem = this.query('li.selected');
-
-    if (selectedItem) {
-      dom.removeClass(selectedItem, 'selected');
     }
   },
 

--- a/src/views/recommended/recommended_item_view.js
+++ b/src/views/recommended/recommended_item_view.js
@@ -1,8 +1,8 @@
-import RecommendedItemView from '../../templates/recommended/item.html';
+import RecommendedItemTemplate from '../../templates/recommended/item.html';
 import RowItemView from '../row_item_view';
 
 export default RowItemView.extend({
-  template: RecommendedItemView,
+  template: RecommendedItemTemplate,
 
   events: RowItemView.prototype.events
 

--- a/src/views/recommended/recommended_item_view.js
+++ b/src/views/recommended/recommended_item_view.js
@@ -14,11 +14,11 @@ export default BaseView.extend({
     // we have to use mousedown, not click, because of browser bugs.
     // see https://github.com/mozilla/universal-search-addon/issues/20 for more.
     if (event.which === 1) {
-      webChannel.sendAutocompleteClick(this.model.url, 'url');
+      webChannel.sendAutocompleteClick(this.model.result, this.model.resultType);
     }
   },
 
   sendSelectionDetails (event) {
-    webChannel.sendUrlSelected(this.model.url, 'url');
+    webChannel.sendUrlSelected(this.model.result, this.model.resultType);
   }
 });

--- a/src/views/recommended/recommended_item_view.js
+++ b/src/views/recommended/recommended_item_view.js
@@ -1,24 +1,9 @@
-import BaseView from '../base_view';
 import RecommendedItemView from '../../templates/recommended/item.html';
-import webChannel from '../../lib/web_channel';
+import RowItemView from '../row_item_view';
 
-export default BaseView.extend({
+export default RowItemView.extend({
   template: RecommendedItemView,
 
-  events: {
-    'mousedown': 'openUrl',
-    'select': 'sendSelectionDetails'
-  },
+  events: RowItemView.prototype.events
 
-  openUrl (event) {
-    // we have to use mousedown, not click, because of browser bugs.
-    // see https://github.com/mozilla/universal-search-addon/issues/20 for more.
-    if (event.which === 1) {
-      webChannel.sendAutocompleteClick(this.model.result, this.model.resultType);
-    }
-  },
-
-  sendSelectionDetails (event) {
-    webChannel.sendUrlSelected(this.model.result, this.model.resultType);
-  }
 });

--- a/src/views/row_item_view.js
+++ b/src/views/row_item_view.js
@@ -1,0 +1,22 @@
+import BaseView from './base_view';
+import webChannel from '../lib/web_channel';
+
+export default BaseView.extend({
+  events: {
+    'mousedown': 'openUrl',
+    'select': 'sendSelectionDetails'
+  },
+
+  openUrl (event) {
+    // we have to use mousedown, not click, because of browser bugs.
+    // see https://github.com/mozilla/universal-search-addon/issues/20 for more.
+    if (event.which === 1) {
+      webChannel.sendAutocompleteClick(this.model.result, this.model.resultType);
+    }
+  },
+
+  sendSelectionDetails (event) {
+    webChannel.sendUrlSelected(this.model.result, this.model.resultType);
+  }
+
+});

--- a/src/views/search_suggestions/search_suggestions_item_view.js
+++ b/src/views/search_suggestions/search_suggestions_item_view.js
@@ -6,19 +6,19 @@ export default BaseView.extend({
   template: SearchSuggestionsItemTemplate,
 
   events: {
-    'mousedown': 'openSuggestion',
+    'mousedown': 'openUrl',
     'select': 'sendSelectionDetails'
   },
 
-  openSuggestion (event) {
+  openUrl (event) {
     // we have to use mousedown, not click, because of browser bugs.
     // see https://github.com/mozilla/universal-search-addon/issues/20 for more.
     if (event.which === 1) {
-      webChannel.sendAutocompleteClick(this.model.term, 'suggestion');
+      webChannel.sendAutocompleteClick(this.model.result, this.model.resultType);
     }
   },
 
   sendSelectionDetails (event) {
-    webChannel.sendUrlSelected(this.model.term, 'suggestion');
+    webChannel.sendUrlSelected(this.model.result, this.model.resultType);
   }
 });

--- a/src/views/search_suggestions/search_suggestions_item_view.js
+++ b/src/views/search_suggestions/search_suggestions_item_view.js
@@ -1,24 +1,9 @@
-import BaseView from '../base_view';
+import RowItemView from '../row_item_view';
 import SearchSuggestionsItemTemplate from '../../templates/search_suggestions/item.html';
-import webChannel from '../../lib/web_channel';
 
-export default BaseView.extend({
+export default RowItemView.extend({
   template: SearchSuggestionsItemTemplate,
 
-  events: {
-    'mousedown': 'openUrl',
-    'select': 'sendSelectionDetails'
-  },
+  events: RowItemView.prototype.events
 
-  openUrl (event) {
-    // we have to use mousedown, not click, because of browser bugs.
-    // see https://github.com/mozilla/universal-search-addon/issues/20 for more.
-    if (event.which === 1) {
-      webChannel.sendAutocompleteClick(this.model.result, this.model.resultType);
-    }
-  },
-
-  sendSelectionDetails (event) {
-    webChannel.sendUrlSelected(this.model.result, this.model.resultType);
-  }
 });


### PR DESCRIPTION
I noticed a lot of near-duplicate code in the views, where we had copy-pasted functions that only varied on the name of the model property.

To eliminate the duplication, I gave the models a uniform API, then extracted the common view methods to a row item view superclass. Seems nicer, except that I've gone with `result` and `resultType` to capture the url/suggestion variation; suggestions for alternative names are welcome :-)

This PR is probably easier to read one commit at a time, rather than skimming the complete diff.

@chuckharmston r?
