### PR TITLE
Display recommended result titles unescaped (fixes #115)

### DIFF
--- a/src/templates/recommended/item.html
+++ b/src/templates/recommended/item.html
@@ -4,7 +4,7 @@
     <img src="{{model.image.url}}"/>
   </figure>
   <div class="segments">
-    <p class="segment title">{{model.title}}</p>
+    <p class="segment title">{{{model.title}}}</p>
     <p class="segment abstract">{{model.abstract}}</p>
     <p class="segment url">{{model.url}}</p>
   </div>


### PR DESCRIPTION
@chuckharmston Sorry to leapfrog your open PR, but Nick and I chatted about this, and it seems like we can trust our own recommendation server--in fact, longer term, we might just xhr html straight into the popup from a constellation of trusted mozilla services. (Of course, there will be security negotiations before we go to prod, but this makes the experience much nicer for now.)
