### PR TITLE
One lodash to rule them all

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
     "html-webpack-plugin": "^1.5.0",
     "loader-utils": "^0.2.10",
     "lodash": "^3.9.3",
-    "lodash.debounce": "^3.1.1",
-    "lodash.throttle": "^3.0.4",
     "mustache-loader": "^0.3.0",
     "node-libs-browser": "^0.5.2",
     "node-normalize-scss": "1.0.3",

--- a/src/adapters/recommended_adapter.js
+++ b/src/adapters/recommended_adapter.js
@@ -1,5 +1,5 @@
 import app from 'ampersand-app';
-import debounce from 'lodash.debounce';
+import {debounce} from 'lodash';
 import webChannel from '../lib/web_channel';
 import RecommendedResults from '../collections/recommended_results';
 

--- a/src/adapters/search_suggestions_adapter.js
+++ b/src/adapters/search_suggestions_adapter.js
@@ -1,5 +1,5 @@
 import State from 'ampersand-state';
-import _c from 'lodash/collection';
+import {collect} from 'lodash';
 import SearchSuggestions from '../collections/search_suggestions';
 import SearchSuggestion from '../models/search_suggestion';
 import webChannel from '../lib/web_channel';
@@ -23,10 +23,10 @@ const SearchSuggestionsAdapter = State.extend({
         this.engine = data.engine;
         this.searchTerm = data.results.term;
 
-        this.remoteSuggestions.reset(_c.collect(data.results.remote, function (t) {
+        this.remoteSuggestions.reset(collect(data.results.remote, function (t) {
           return { term: t, type: 'remote' };
         }));
-        this.localSuggestions.reset(_c.collect(data.results.local, function (t) {
+        this.localSuggestions.reset(collect(data.results.local, function (t) {
           return { term: t, type: 'local' };
         }));
 

--- a/src/views/base_view.js
+++ b/src/views/base_view.js
@@ -1,7 +1,6 @@
 import AmpersandView from 'ampersand-view';
 import dom from 'ampersand-dom';
-import flatten from 'lodash/array/flatten';
-import invoke from 'lodash/collection/invoke';
+import {flatten, invoke} from 'lodash';
 
 export default AmpersandView.extend({
   render () {

--- a/src/views/index_view.js
+++ b/src/views/index_view.js
@@ -10,7 +10,7 @@ import SearchSuggestionsIndexView from './search_suggestions/search_suggestions_
 import ActivityIndexView from './activity/activity_index_view';
 import IndexTemplate from '../templates/index.html';
 import webChannel from '../lib/web_channel';
-import throttle from 'lodash.throttle';
+import {throttle} from 'lodash';
 import dom from 'ampersand-dom';
 
 export default BaseView.extend({


### PR DESCRIPTION
Uses the one master **lodash** dependency, and removes the two method-specific lodash dependencies.

Fixes #129
